### PR TITLE
Upgrade PyTorch Lightning version to 1.7.2 from 1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ scipy
 tqdm
 wandb
 hydra-core
-pytorch_lightning==1.7
+pytorch_lightning==1.7.2
 torchmetrics
 torch==1.11
 --extra-index-url https://download.pytorch.org/whl/cu113


### PR DESCRIPTION
`Warning 1` mentioned in the README has been fixed in a later version of PyTorch Lightning ([changelog](https://pytorch-lightning.readthedocs.io/en/stable/generated/CHANGELOG.html#:~:text=0.7.0%20(13967)-,%5B1.7.2%5D%20%2D%20Fixed,-Fixed%20a%20bug)). Upgrading the PL requirement to 1.7.2 removes the error which becomes very annoying while debugging/testing.