### PR TITLE
In guacamol dataset and processed_file_names, use self.filter_dataset instead of self.filter

### DIFF
--- a/src/datasets/guacamol_dataset.py
+++ b/src/datasets/guacamol_dataset.py
@@ -84,7 +84,7 @@ class GuacamolDataset(InMemoryDataset):
 
     @property
     def processed_file_names(self):
-        if self.filter:
+        if self.filter_dataset:
             return ['new_proc_tr.pt', 'new_proc_val.pt', 'new_proc_test.pt']
         else:
             return ['old_proc_tr.pt', 'old_proc_val.pt', 'old_proc_test.pt']


### PR DESCRIPTION
I believe it should be self.filter_dataset (and not self.filter) as that is the attribute that is set in the constructor of GuacamolDataset