### PR TITLE
Update diffusion_model_discrete.py

### DIFF
--- a/src/diffusion_model_discrete.py
+++ b/src/diffusion_model_discrete.py
@@ -143,7 +143,10 @@ class DiscreteDenoisingDiffusion(pl.LightningModule):
                       f" -- {time.time() - self.start_epoch_time:.1f}s ")
         epoch_at_metrics, epoch_bond_metrics = self.train_metrics.log_epoch_metrics()
         self.print(f"Epoch {self.current_epoch}: {epoch_at_metrics} -- {epoch_bond_metrics}")
-        print(torch.cuda.memory_summary())
+        if torch.cuda.is_available():
+            print(torch.cuda.memory_summary())
+        else:
+            print("CUDA is not available. Skipping memory summary.")
 
     def on_validation_epoch_start(self) -> None:
         self.val_nll.reset()


### PR DESCRIPTION
Avoid error, when GPU is not available.

if torch.cuda.is_available():
    print(torch.cuda.memory_summary())
else:
    print("CUDA is not available. Skipping memory summary.")